### PR TITLE
minor change on string trim

### DIFF
--- a/cpp/core/global.cpp
+++ b/cpp/core/global.cpp
@@ -288,13 +288,10 @@ string Global::chopSuffix(const string& s, const string& suffix)
 
 string Global::trim(const string& s)
 {
-  size_t p2 = s.find_last_not_of(" \t\r\n");
+  size_t p2 = s.find_last_not_of(" \t\r\n\v\f");
   if (p2 == string::npos)
     return string();
-  size_t p1 = s.find_first_not_of(" \t\r\n");
-  if (p1 == string::npos)
-    p1 = 0;
-
+  size_t p1 = s.find_first_not_of(" \t\r\n\v\f");
   return s.substr(p1,(p2-p1)+1);
 }
 


### PR DESCRIPTION
Very minor changes. Since we already checked 
```
if (p2 == string::npos)
    return string();
```
We do not need `if (p2 == string::npos)`. 
I also added white space string as `\v\f` into `" \t\r\n\v\f"` based on C++ reference.  All are very minor changes. 